### PR TITLE
Fixes to the auto complete problem

### DIFF
--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
@@ -52,7 +52,7 @@ public interface DiscordCommandFactory<C> {
 
     /**
      * A getter for the current set suggestion registration mapper.
-     * @see DiscordCommandFactory#setSuggestionRegistrationMapper
+     * @see DiscordCommandFactory#suggestionRegistrationMapper(Function) 
      * @return The current set suggestion registration mapper.
      */
     @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper();

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
@@ -47,12 +47,13 @@ public interface DiscordCommandFactory<C> {
      * @param suggestionRegistrationMapper The function to map suggestion providers to other suggestion provider during
      *                                     registration of the command to discord.
      */
-    void setSuggestionRegistrationMapper(Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper);
+    void setSuggestionRegistrationMapper(@NonNull Function<SuggestionProvider<C>,
+                                         SuggestionProvider<C>> suggestionRegistrationMapper);
 
     /**
      * A getter for the current set suggestion registration mapper.
      * @see DiscordCommandFactory#setSuggestionRegistrationMapper
      * @return The current set suggestion registration mapper.
      */
-    Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper();
+    @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper();
 }

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
@@ -23,11 +23,11 @@
 //
 package org.incendo.cloud.discord.slash;
 
+import java.util.function.Function;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.cloud.internal.CommandNode;
 import org.incendo.cloud.suggestion.SuggestionProvider;
-import java.util.function.Function;
 
 @API(status = API.Status.STABLE, since = "1.0.0")
 public interface DiscordCommandFactory<C> {
@@ -41,9 +41,12 @@ public interface DiscordCommandFactory<C> {
     @NonNull DiscordCommand<C> create(@NonNull CommandNode<C> node);
 
     /**
-     * This allows you to change the way some {@link SuggestionProvider}s are handled during registration of the command. If
-     * you would like to use choices you can return {@link DiscordChoices}, or you could return
-     * {@link SuggestionProvider#noSuggestions()} to disable auto-complete for the argument (option).
+     * Sets the suggestion registration mapper.
+     *
+     * <p>The suggestion registration mapper determines how {@link SuggestionProvider}s are handled during registration of the
+     * command. {@link DiscordChoices} can be returned to use native Discord choices, or
+     * {@link SuggestionProvider#noSuggestions()} can be returned to disable auto-complete for the argument.</p>
+     *
      * @param suggestionRegistrationMapper The function to map suggestion providers to other suggestion provider during
      *                                     registration of the command to discord.
      */
@@ -51,8 +54,9 @@ public interface DiscordCommandFactory<C> {
                                          SuggestionProvider<C>> suggestionRegistrationMapper);
 
     /**
-     * A getter for the current set suggestion registration mapper.
-     * @see DiscordCommandFactory#suggestionRegistrationMapper(Function) 
+     * Returns the current suggestion registration mapper.
+     *
+     * @see DiscordCommandFactory#suggestionRegistrationMapper(Function)
      * @return The current set suggestion registration mapper.
      */
     @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper();

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
@@ -47,7 +47,7 @@ public interface DiscordCommandFactory<C> {
      * @param suggestionRegistrationMapper The function to map suggestion providers to other suggestion provider during
      *                                     registration of the command to discord.
      */
-    void setSuggestionRegistrationMapper(@NonNull Function<SuggestionProvider<C>,
+    void suggestionRegistrationMapper(@NonNull Function<SuggestionProvider<C>,
                                          SuggestionProvider<C>> suggestionRegistrationMapper);
 
     /**
@@ -55,5 +55,5 @@ public interface DiscordCommandFactory<C> {
      * @see DiscordCommandFactory#setSuggestionRegistrationMapper
      * @return The current set suggestion registration mapper.
      */
-    @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper();
+    @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper();
 }

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/DiscordCommandFactory.java
@@ -26,6 +26,8 @@ package org.incendo.cloud.discord.slash;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.incendo.cloud.internal.CommandNode;
+import org.incendo.cloud.suggestion.SuggestionProvider;
+import java.util.function.Function;
 
 @API(status = API.Status.STABLE, since = "1.0.0")
 public interface DiscordCommandFactory<C> {
@@ -37,4 +39,20 @@ public interface DiscordCommandFactory<C> {
      * @return the option
      */
     @NonNull DiscordCommand<C> create(@NonNull CommandNode<C> node);
+
+    /**
+     * This allows you to change the way some {@link SuggestionProvider}s are handled during registration of the command. If
+     * you would like to use choices you can return {@link DiscordChoices}, or you could return
+     * {@link SuggestionProvider#noSuggestions()} to disable auto-complete for the argument (option).
+     * @param suggestionRegistrationMapper The function to map suggestion providers to other suggestion provider during
+     *                                     registration of the command to discord.
+     */
+    void setSuggestionRegistrationMapper(Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper);
+
+    /**
+     * A getter for the current set suggestion registration mapper.
+     * @see DiscordCommandFactory#setSuggestionRegistrationMapper
+     * @return The current set suggestion registration mapper.
+     */
+    Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper();
 }

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
@@ -151,12 +151,12 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
     }
 
     @Override
-    public void setSuggestionRegistrationMapper(final Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
+    public void setSuggestionRegistrationMapper(final @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
         this.suggestionRegistrationMapper = Objects.requireNonNull(suggestionRegistrationMapper);
     }
 
     @Override
-    public Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper() {
+    public @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper() {
         return suggestionRegistrationMapper;
     }
 

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apiguardian.api.API;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -57,6 +58,8 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
 
     private final OptionRegistry<C> optionRegistry;
     private final Map<Class<?>, RangeMapper<C, ?, ?>> rangeMappers = new HashMap<>();
+
+    private Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper = provider -> provider;
 
     /**
      * Creates a new factory instance.
@@ -147,6 +150,16 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
                 .build();
     }
 
+    @Override
+    public void setSuggestionRegistrationMapper(final Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
+        this.suggestionRegistrationMapper = Objects.requireNonNull(suggestionRegistrationMapper);
+    }
+
+    @Override
+    public Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper() {
+        return suggestionRegistrationMapper;
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     private @NonNull List<DiscordOption<C>> createOptions(final @NonNull CommandNode<C> node) {
         final CommandComponent<C> component = node.component();
@@ -201,13 +214,14 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
 
         return components.stream()
                 .map(innerComponent -> {
+                    SuggestionProvider<C> suggestionProvider = suggestionRegistrationMapper.apply(innerComponent.suggestionProvider());
                     final DiscordOptionType optionType = this.optionRegistry.getOption(innerComponent.valueType());
-                    final Collection choices = this.extractChoices(innerComponent.suggestionProvider());
+                    final Collection choices = this.extractChoices(suggestionProvider);
                     final Range<?> range = this.extractRange(innerComponent.parser());
 
                     final boolean autoComplete;
                     if (choices.isEmpty()) {
-                        autoComplete = DiscordOptionType.AUTOCOMPLETE.contains(optionType);
+                        autoComplete = !(suggestionProvider.equals(SuggestionProvider.noSuggestions()));
                     } else {
                         autoComplete = false;
                     }

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
@@ -151,13 +151,15 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
     }
 
     @Override
-    public void suggestionRegistrationMapper(final @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
+    public void suggestionRegistrationMapper(
+            final @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper
+    ) {
         this.suggestionRegistrationMapper = Objects.requireNonNull(suggestionRegistrationMapper);
     }
 
     @Override
     public @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper() {
-        return suggestionRegistrationMapper;
+        return this.suggestionRegistrationMapper;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -214,14 +216,17 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
 
         return components.stream()
                 .map(innerComponent -> {
-                    SuggestionProvider<C> suggestionProvider = this.suggestionRegistrationMapper.apply(innerComponent.suggestionProvider());
+                    final SuggestionProvider<C> suggestionProvider = this.suggestionRegistrationMapper.apply(
+                            innerComponent.suggestionProvider()
+                    );
                     final DiscordOptionType optionType = this.optionRegistry.getOption(innerComponent.valueType());
                     final Collection choices = this.extractChoices(suggestionProvider);
                     final Range<?> range = this.extractRange(innerComponent.parser());
 
                     final boolean autoComplete;
                     if (choices.isEmpty()) {
-                        autoComplete = !(suggestionProvider.equals(SuggestionProvider.noSuggestions()));
+                        autoComplete = DiscordOptionType.AUTOCOMPLETE.contains(optionType)
+                                        && !suggestionProvider.equals(SuggestionProvider.noSuggestions());
                     } else {
                         autoComplete = false;
                     }

--- a/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
+++ b/cloud-discord-common/src/main/java/org/incendo/cloud/discord/slash/StandardDiscordCommandFactory.java
@@ -151,12 +151,12 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
     }
 
     @Override
-    public void setSuggestionRegistrationMapper(final @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
+    public void suggestionRegistrationMapper(final @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper) {
         this.suggestionRegistrationMapper = Objects.requireNonNull(suggestionRegistrationMapper);
     }
 
     @Override
-    public @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> getSuggestionRegistrationMapper() {
+    public @NonNull Function<SuggestionProvider<C>, SuggestionProvider<C>> suggestionRegistrationMapper() {
         return suggestionRegistrationMapper;
     }
 
@@ -214,7 +214,7 @@ public class StandardDiscordCommandFactory<C> implements DiscordCommandFactory<C
 
         return components.stream()
                 .map(innerComponent -> {
-                    SuggestionProvider<C> suggestionProvider = suggestionRegistrationMapper.apply(innerComponent.suggestionProvider());
+                    SuggestionProvider<C> suggestionProvider = this.suggestionRegistrationMapper.apply(innerComponent.suggestionProvider());
                     final DiscordOptionType optionType = this.optionRegistry.getOption(innerComponent.valueType());
                     final Collection choices = this.extractChoices(suggestionProvider);
                     final Range<?> range = this.extractRange(innerComponent.parser());


### PR DESCRIPTION
This pull request solves auto completion issues. Here are the exact changes:

1. Added a check whether the suggestion provider of an argument is the same one as `SuggestionProvider#noSuggestions()`.
2. Before dealing with the `SuggestionProvider` during registration it would first run the suggestion registration mapper, which will allow you to map providers to discord choices or `SuggestionProvider#noSuggestions()` (disable auto complete) by setting it on the command factory.

The suggestion registration mapper is very useful when mapping providers that return constant values, or provide suggestions that would be barely helpful and you would like to disable it completely.


The suggestion registration mapper might not be the best idea, If you aren't fine with it or have better ways to solve the same problem, Let me know!

resolves #47 