### PR TITLE
fix(kord): don't NPE when publishing commands that take arguments

### DIFF
--- a/cloud-kord/src/main/kotlin/org/incendo/cloud/discord/kord/StandardKordCommandFactory.kt
+++ b/cloud-kord/src/main/kotlin/org/incendo/cloud/discord/kord/StandardKordCommandFactory.kt
@@ -106,7 +106,8 @@ internal class StandardKordCommandFactory<C : Any>(
         }
     }
 
-    private fun MultiApplicationCommandBuilder.createCommands(scope: CommandScope<C>) {
+    // Visible for testing; there is no other way to run this without a live Kord instance.
+    internal fun MultiApplicationCommandBuilder.createCommands(scope: CommandScope<C>) {
         nodeProcessor.prepareTree()
 
         commandTree.rootNodes().forEach { rootNode ->
@@ -123,11 +124,13 @@ internal class StandardKordCommandFactory<C : Any>(
             input(discordCommand.name(), discordCommand.description()) {
                 createCommand(discordCommand)
 
-                // It's the best we've got
+                // It's the best we've got.
+                // A root node only carries a command when it is executable on its own, so command() is
+                // null for anything that takes arguments or has subcommands.
                 val accessMap = rootNode.nodeMeta().getOrNull(CommandNode.META_KEY_ACCESS)
-                val senderType = rootNode.command().senderType().map { v -> v.type }.orElse(null)
+                val senderType = rootNode.command()?.senderType()?.map { v -> v.type }?.orElse(null)
 
-                accessMap?.get(senderType)
+                senderType?.let { accessMap?.get(it) }
                     ?.let { it as? DiscordPermission }
                     ?.permissionString()
                     ?.let { DiscordBitSet(it) }

--- a/cloud-kord/src/test/kotlin/org/incendo/cloud/discord/kord/StandardKordCommandFactoryTest.kt
+++ b/cloud-kord/src/test/kotlin/org/incendo/cloud/discord/kord/StandardKordCommandFactoryTest.kt
@@ -1,0 +1,78 @@
+//
+// MIT License
+//
+// Copyright (c) 2024 Incendo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+package org.incendo.cloud.discord.kord
+
+import com.google.common.truth.Truth.assertThat
+import dev.kord.rest.builder.interaction.GlobalMultiApplicationCommandBuilder
+import org.incendo.cloud.discord.slash.CommandScope
+import org.incendo.cloud.execution.ExecutionCoordinator
+import org.incendo.cloud.parser.standard.StringParser.stringParser
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class StandardKordCommandFactoryTest {
+
+    private lateinit var commandManager: KordCommandManager<KordInteraction>
+    private lateinit var commandFactory: StandardKordCommandFactory<KordInteraction>
+
+    @BeforeEach
+    fun setup() {
+        commandManager = KordCommandManager(ExecutionCoordinator.simpleCoordinator()) { it }
+        @Suppress("UNCHECKED_CAST")
+        commandFactory = commandManager.commandFactory as StandardKordCommandFactory<KordInteraction>
+    }
+
+    @Test
+    fun testCreateCommandWithArgument() {
+        // Arrange
+        commandManager.command(
+            commandManager.commandBuilder("command")
+                .required("string", stringParser())
+        )
+        val builder = GlobalMultiApplicationCommandBuilder()
+
+        // Act
+        with(commandFactory) {
+            builder.createCommands(CommandScope.global())
+        }
+
+        // Assert
+        assertThat(builder.commands.map { it.name }).containsExactly("command")
+    }
+
+    @Test
+    fun testCreateCommandWithoutArgument() {
+        // Arrange
+        commandManager.command(commandManager.commandBuilder("command"))
+        val builder = GlobalMultiApplicationCommandBuilder()
+
+        // Act
+        with(commandFactory) {
+            builder.createCommands(CommandScope.global())
+        }
+
+        // Assert
+        assertThat(builder.commands.map { it.name }).containsExactly("command")
+    }
+}


### PR DESCRIPTION
Registering any command whose root literal isn't executable on its own kills the publish:

```
java.lang.NullPointerException: Cannot invoke "org.incendo.cloud.Command.senderType()" because the return value of "org.incendo.cloud.internal.CommandNode.command()" is null
	at org.incendo.cloud.discord.kord.StandardKordCommandFactory.createCommands(StandardKordCommandFactory.kt:128)
	at org.incendo.cloud.discord.kord.StandardKordCommandFactory.createGlobalCommands(StandardKordCommandFactory.kt:99)
	at org.incendo.cloud.discord.kord.KordEventListener.listen(KordEventListener.kt:79)
```

`CommandNode#command()` is `@MonotonicNonNull` and only gets populated on nodes that terminate a command, so a root literal carries one only when the whole command is that literal and nothing else. `/ping` is fine; `/warn <user>` or a command with subcommands is not. Kotlin sees the getter as a platform type, so nothing complains at compile time and the first `createGlobalCommands` call takes the bot's command registration down with it.

The same permission lookup landed in jda5 in #60 with a `rootNode.command() != null` guard around it (still there in cloud-jda6). kord's copy never got one. This ports it over.

Reproduced and verified against 1.0.0-beta.4 in a bot with `/warn <user>`, `/clear-chat <amount>` and a couple of subcommand groups. Before: publish dies on the first one. After: everything registers.

### about the test

There was no test source set for cloud-kord, so I added one. To reach `createCommands` I had to widen it from `private` to `internal` — everything above it wants a live `Kord`, and `MultiApplicationCommandBuilder`'s concrete subclasses are constructible on their own, so this was the cheapest seam. The class itself is already `internal`, so no public API moves. Say the word if you'd rather I drop the test and the visibility bump and keep this to the two-line fix.

`testCreateCommandWithArgument` fails with the NPE above on master and passes with the fix; `testCreateCommandWithoutArgument` passes either way.

### what this doesn't fix

Commands that take arguments still won't get a default member permission applied, since there's no root command to read a sender type from. I think that's what #91 is about. Resolving it properly means deciding which descendant's sender type a root should answer with, which felt like a different PR.
